### PR TITLE
initialize base class for stack trace messages

### DIFF
--- a/django_inscode/exceptions.py
+++ b/django_inscode/exceptions.py
@@ -27,6 +27,7 @@ class APIException(Exception):
         self.message = message or self.default_message
         self.status_code = status_code or self.status_code
         self.errors = errors or []
+        super().__init__(self.message, self.errors)
 
     def to_dict(self):
         """


### PR DESCRIPTION
Tiny addition for QoL for cases where you'd face the exception without the middleware (e.g, a custom command).