### PR TITLE
Fix BadRequest occlusion

### DIFF
--- a/django_inscode/repositories.py
+++ b/django_inscode/repositories.py
@@ -271,6 +271,8 @@ class Repository(IRepository):
 
             except ValidationError as e:
                 raise BadRequest(errors=self._format_validation_errors(e))
+            except BadRequest as e:
+                raise e
             except Exception as e:
                 raise InternalServerError(errors={"internal_server_error": str(e)})
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(f):
 
 setup(
     name="django-inscode",
-    version="1.7.7",
+    version="1.7.8",
     description="Django framework da Inscode.",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The BadRequests raised during the m2m data loop on Repository._save were being hidden by this `except Exception`, which wouldn't also show the error in its InternalServerError message 'cause BaseException __str__ depends on the args it was initialized with (same case as #48).

There are only BadRequests being raised during the loop, but i can imagine excepting APIException in general to raise through