### PR TITLE
Feat/updatable fields and context validate

### DIFF
--- a/django_inscode/authentication.py
+++ b/django_inscode/authentication.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 from .exceptions import Unauthorized
@@ -79,7 +78,7 @@ class KeycloakBearerAuthentication(BaseAuthentication):
             return user
 
         except Exception as e:
-            raise Unauthorized("Token inválido ou expirado.")
+            raise Unauthorized("Token inválido ou expirado.") from e
 
     def get_or_create_user(self, backend, claims):
         """

--- a/django_inscode/exceptions.py
+++ b/django_inscode/exceptions.py
@@ -12,7 +12,8 @@ class APIException(Exception):
         errors (list): Lista de erros específicos associados à exceção.
     """
 
-    status_code: ClassVar[int] = 500
+    # NOTE: an alternative would be changing the instance status_code variable name
+    status_code: int = 500
     default_message: ClassVar[str] = "A server error occurred."
 
     def __init__(self, message=None, status_code=None, errors=None):

--- a/django_inscode/exceptions.py
+++ b/django_inscode/exceptions.py
@@ -12,7 +12,6 @@ class APIException(Exception):
         errors (list): Lista de erros específicos associados à exceção.
     """
 
-    # NOTE: an alternative would be changing the instance status_code variable name
     status_code: int = 500
     default_message: ClassVar[str] = "A server error occurred."
 

--- a/django_inscode/middlewares.py
+++ b/django_inscode/middlewares.py
@@ -38,15 +38,13 @@ class ExceptionHandlingMiddleware:
                 if isinstance(transformed, APIException):
                     return JsonResponse(
                         transformed.to_dict(),
-                        status=transformed.default_status_code,
+                        status=transformed.status_code,
                     )
 
                 return transformed
 
         if isinstance(exception, APIException):
-            return JsonResponse(
-                exception.to_dict(), status=exception.default_status_code
-            )
+            return JsonResponse(exception.to_dict(), status=exception.status_code)
 
         return JsonResponse(
             {

--- a/django_inscode/middlewares.py
+++ b/django_inscode/middlewares.py
@@ -1,6 +1,7 @@
-from django.http import JsonResponse
-from django.conf import settings
 from typing import Callable
+
+from django.conf import settings
+from django.http import JsonResponse
 
 from .exceptions import APIException
 
@@ -37,13 +38,15 @@ class ExceptionHandlingMiddleware:
                 if isinstance(transformed, APIException):
                     return JsonResponse(
                         transformed.to_dict(),
-                        status=transformed.status_code,
+                        status=transformed.default_status_code,
                     )
 
                 return transformed
 
         if isinstance(exception, APIException):
-            return JsonResponse(exception.to_dict(), status=exception.status_code)
+            return JsonResponse(
+                exception.to_dict(), status=exception.default_status_code
+            )
 
         return JsonResponse(
             {
@@ -71,6 +74,7 @@ class _ExceptionMapper:
           - uma instância de APIException (será retornada diretamente)
           - um callable que recebe a exceção original e retorna uma APIException
         """
+
         def transformer(exc):
             if callable(value):
                 return value(exc)

--- a/django_inscode/mixins.py
+++ b/django_inscode/mixins.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from django_inscode.services import GenericModelService
 
 from . import exceptions, settings
+from .types import Context, Data
 
 
 class ServiceCreateMixin[T: Model]:
@@ -20,7 +21,7 @@ class ServiceCreateMixin[T: Model]:
         create: Cria uma nova instância do modelo.
     """
 
-    def create(self: "GenericModelService[T]", data: dict, context: dict) -> T:
+    def create(self: "GenericModelService[T]", data: Data, context: Context) -> T:
         """
         Cria uma nova instância do modelo.
 
@@ -44,7 +45,7 @@ class ServiceReadMixin[T: Model]:
         list: Lista instâncias filtradas do modelo.
     """
 
-    def read(self: "GenericModelService[T]", id: UUID | int, context: dict) -> T:
+    def read(self: "GenericModelService[T]", id: UUID | int, context: Context) -> T:
         """
         Lê uma instância específica pelo ID.
 
@@ -58,7 +59,7 @@ class ServiceReadMixin[T: Model]:
         model_repository = self.get_model_repository()
         return model_repository.read(id)
 
-    def list(self: "GenericModelService[T]", context: dict, **kwargs) -> QuerySet[T]:
+    def list(self: "GenericModelService[T]", context: Context, **kwargs) -> QuerySet[T]:
         """
         Lista instâncias filtradas do modelo.
 
@@ -82,7 +83,7 @@ class ServiceUpdateMixin[T: Model]:
     """
 
     def update(
-        self: "GenericModelService[T]", id: UUID | int, data: dict, context: dict
+        self: "GenericModelService[T]", id: UUID | int, data: Data, context: Context
     ) -> T:
         """
         Atualiza uma instância específica pelo ID.
@@ -107,7 +108,9 @@ class ServiceDeleteMixin[T: Model]:
         delete: Exclui uma instância específica pelo ID.
     """
 
-    def delete(self: "GenericModelService[T]", id: UUID | int, context: dict) -> None:
+    def delete(
+        self: "GenericModelService[T]", id: UUID | int, context: Context
+    ) -> None:
         """
         Exclui uma instância específica pelo ID.
 
@@ -120,10 +123,6 @@ class ServiceDeleteMixin[T: Model]:
         """
         model_repository = self.get_model_repository()
         return model_repository.delete(id)
-
-
-# NOTE: couldn't find a way to tell that self should behave both like a GenericModelView
-# and a mixin at the same time (needed as they call their own methods here)
 
 
 class ViewCreateModelMixin:

--- a/django_inscode/mixins.py
+++ b/django_inscode/mixins.py
@@ -1,15 +1,14 @@
+from math import ceil
+from typing import Any, ClassVar, cast
 from uuid import UUID
-from typing import Dict, Any, Optional, ClassVar
 
+from django.db.models import Model, QuerySet
 from django.http import HttpRequest, JsonResponse
-from django.db.models import QuerySet, Model
-
 from django_filters import FilterSet
 
 from math import ceil
 
-from . import settings
-from . import exceptions
+from . import exceptions, settings
 
 
 class ServiceCreateMixin:
@@ -20,13 +19,13 @@ class ServiceCreateMixin:
         create: Cria uma nova instância do modelo.
     """
 
-    def create(self, data: Dict, context: Dict) -> Model:
+    def create(self, data: dict, context: dict) -> Model:
         """
         Cria uma nova instância do modelo.
 
         Args:
-            data (Dict): Dados para criação do objeto.
-            context (Dict): Contexto adicional para a operação.
+            data (dict): Dados para criação do objeto.
+            context (dict): Contexto adicional para a operação.
 
         Returns:
             t_model: Instância criada do modelo.
@@ -44,13 +43,13 @@ class ServiceReadMixin:
         list: Lista instâncias filtradas do modelo.
     """
 
-    def read(self, id: UUID | int, context: Dict) -> Model:
+    def read(self, id: UUID | int, context: dict) -> Model:
         """
         Lê uma instância específica pelo ID.
 
         Args:
             id (UUID | int): Identificador da instância.
-            context (Dict): Contexto adicional para a operação.
+            context (dict): Contexto adicional para a operação.
 
         Returns:
             t_model: Instância do modelo correspondente ao ID.
@@ -58,12 +57,12 @@ class ServiceReadMixin:
         model_repository = self.get_model_repository()
         return model_repository.read(id)
 
-    def list(self, context: Dict, **kwargs) -> QuerySet[Model]:
+    def list(self, context: dict, **kwargs) -> QuerySet[Model]:
         """
         Lista instâncias filtradas do modelo.
 
         Args:
-            context (Dict): Contexto adicional para a operação.
+            context (dict): Contexto adicional para a operação.
             **kwargs: Filtros adicionais para a consulta.
 
         Returns:
@@ -81,14 +80,14 @@ class ServiceUpdateMixin:
         update: Atualiza uma instância específica pelo ID.
     """
 
-    def update(self, id: UUID | int, data: Dict, context: Dict) -> Model:
+    def update(self, id: UUID | int, data: dict, context: dict) -> Model:
         """
         Atualiza uma instância específica pelo ID.
 
         Args:
             id (UUID | int): Identificador da instância.
-            data (Dict): Dados atualizados da instância.
-            context (Dict): Contexto adicional para a operação.
+            data (dict): Dados atualizados da instância.
+            context (dict): Contexto adicional para a operação.
 
         Returns:
             t_model: Instância atualizada do modelo.
@@ -105,13 +104,13 @@ class ServiceDeleteMixin:
         delete: Exclui uma instância específica pelo ID.
     """
 
-    def delete(self, id: UUID | int, context: Dict) -> None:
+    def delete(self, id: UUID | int, context: dict) -> None:
         """
         Exclui uma instância específica pelo ID.
 
         Args:
             id (UUID | int): Identificador da instância.
-            context (Dict): Contexto adicional para a operação.
+            context (dict): Contexto adicional para a operação.
 
         Returns:
             None
@@ -163,9 +162,9 @@ class ViewRetrieveModelMixin:
     """
 
     paginate_by: ClassVar[int] = settings.DEFAULT_PAGINATED_BY
-    filter_class: ClassVar[FilterSet] = None
+    filter_class: ClassVar[type[FilterSet]] = cast(type[FilterSet], None)
 
-    def get_filter_class(self) -> Optional[FilterSet]:
+    def get_filter_class(self) -> type[FilterSet] | None:
         """
         Retorna a classe de filtro caso esta esteja especificada.
         """
@@ -176,12 +175,12 @@ class ViewRetrieveModelMixin:
 
         return self.filter_class
 
-    def get_queryset(self, filter_kwargs: Optional[Dict[str, Any]] = None):
+    def get_queryset(self, filter_kwargs: dict[str, Any] | None = None):
         """
         Retorna o queryset filtrado com base nos argumentos fornecidos.
 
         Args:
-            filter_kwargs (Optional[Dict[str, Any]]): Dicionário contendo filtros opcionais.
+            filter_kwargs (dict[str, Any] | None): Dicionário contendo filtros opcionais.
 
         Returns:
             QuerySet: Queryset filtrado com base nos critérios fornecidos.
@@ -265,12 +264,12 @@ class ViewRetrieveModelMixin:
         serialized_data = [self.serialize_object(obj) for obj in paginated_queryset]
 
         total_items = queryset.count()
-        
+
         response_data = {
             "pagination": {
                 "current_page": page_number,
                 "total_items": total_items,
-                "total_pages": ceil(total_items/self.paginate_by),
+                "total_pages": ceil(total_items / self.paginate_by),
                 "has_next": len(paginated_queryset) == self.paginate_by,
                 "has_previous": page_number > 1,
             },
@@ -416,5 +415,4 @@ __all__ = [
     "ViewRetrieveModelMixin",
     "ViewUpdateModelMixin",
     "ViewDeleteModelMixin",
-    "ContentTypeHandlerMixin",
 ]

--- a/django_inscode/mixins.py
+++ b/django_inscode/mixins.py
@@ -1,6 +1,5 @@
 from math import ceil
 from typing import TYPE_CHECKING, Any, ClassVar, cast
-from uuid import UUID
 
 from django.db.models import Model, QuerySet
 from django.http import HttpRequest, JsonResponse
@@ -10,7 +9,7 @@ if TYPE_CHECKING:
     from django_inscode.services import GenericModelService
 
 from . import exceptions, settings
-from .types import Context, Data
+from .types import Context, Data, Id
 
 
 class ServiceCreateMixin[T: Model]:
@@ -45,12 +44,12 @@ class ServiceReadMixin[T: Model]:
         list: Lista instâncias filtradas do modelo.
     """
 
-    def read(self: "GenericModelService[T]", id: UUID | int, context: Context) -> T:
+    def read(self: "GenericModelService[T]", id: Id, context: Context) -> T:
         """
         Lê uma instância específica pelo ID.
 
         Args:
-            id (UUID | int): Identificador da instância.
+            id ((UUID, int)): Identificador da instância.
             context (dict): Contexto adicional para a operação.
 
         Returns:
@@ -83,13 +82,13 @@ class ServiceUpdateMixin[T: Model]:
     """
 
     def update(
-        self: "GenericModelService[T]", id: UUID | int, data: Data, context: Context
+        self: "GenericModelService[T]", id: Id, data: Data, context: Context
     ) -> T:
         """
         Atualiza uma instância específica pelo ID.
 
         Args:
-            id (UUID | int): Identificador da instância.
+            id ((UUID, int)): Identificador da instância.
             data (dict): Dados atualizados da instância.
             context (dict): Contexto adicional para a operação.
 
@@ -108,14 +107,12 @@ class ServiceDeleteMixin[T: Model]:
         delete: Exclui uma instância específica pelo ID.
     """
 
-    def delete(
-        self: "GenericModelService[T]", id: UUID | int, context: Context
-    ) -> None:
+    def delete(self: "GenericModelService[T]", id: Id, context: Context) -> None:
         """
         Exclui uma instância específica pelo ID.
 
         Args:
-            id (UUID | int): Identificador da instância.
+            id ((UUID, int)): Identificador da instância.
             context (dict): Contexto adicional para a operação.
 
         Returns:

--- a/django_inscode/mixins.py
+++ b/django_inscode/mixins.py
@@ -1,12 +1,13 @@
 from math import ceil
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from uuid import UUID
 
 from django.db.models import Model, QuerySet
 from django.http import HttpRequest, JsonResponse
 from django_filters import FilterSet
 
-from django_inscode.services import GenericModelService
+if TYPE_CHECKING:
+    from django_inscode.services import GenericModelService
 
 from . import exceptions, settings
 
@@ -19,7 +20,7 @@ class ServiceCreateMixin[T: Model]:
         create: Cria uma nova instância do modelo.
     """
 
-    def create(self: GenericModelService[T], data: dict, context: dict) -> T:
+    def create(self: "GenericModelService[T]", data: dict, context: dict) -> T:
         """
         Cria uma nova instância do modelo.
 
@@ -43,7 +44,7 @@ class ServiceReadMixin[T: Model]:
         list: Lista instâncias filtradas do modelo.
     """
 
-    def read(self: GenericModelService[T], id: UUID | int, context: dict) -> T:
+    def read(self: "GenericModelService[T]", id: UUID | int, context: dict) -> T:
         """
         Lê uma instância específica pelo ID.
 
@@ -57,7 +58,7 @@ class ServiceReadMixin[T: Model]:
         model_repository = self.get_model_repository()
         return model_repository.read(id)
 
-    def list(self: GenericModelService[T], context: dict, **kwargs) -> QuerySet[T]:
+    def list(self: "GenericModelService[T]", context: dict, **kwargs) -> QuerySet[T]:
         """
         Lista instâncias filtradas do modelo.
 
@@ -81,7 +82,7 @@ class ServiceUpdateMixin[T: Model]:
     """
 
     def update(
-        self: GenericModelService[T], id: UUID | int, data: dict, context: dict
+        self: "GenericModelService[T]", id: UUID | int, data: dict, context: dict
     ) -> T:
         """
         Atualiza uma instância específica pelo ID.
@@ -106,7 +107,7 @@ class ServiceDeleteMixin[T: Model]:
         delete: Exclui uma instância específica pelo ID.
     """
 
-    def delete(self: GenericModelService[T], id: UUID | int, context: dict) -> None:
+    def delete(self: "GenericModelService[T]", id: UUID | int, context: dict) -> None:
         """
         Exclui uma instância específica pelo ID.
 

--- a/django_inscode/mixins.py
+++ b/django_inscode/mixins.py
@@ -6,12 +6,12 @@ from django.db.models import Model, QuerySet
 from django.http import HttpRequest, JsonResponse
 from django_filters import FilterSet
 
-from math import ceil
+from django_inscode.services import GenericModelService
 
 from . import exceptions, settings
 
 
-class ServiceCreateMixin:
+class ServiceCreateMixin[T: Model]:
     """
     Mixin para criar instâncias de um modelo em um serviço.
 
@@ -19,7 +19,7 @@ class ServiceCreateMixin:
         create: Cria uma nova instância do modelo.
     """
 
-    def create(self, data: dict, context: dict) -> Model:
+    def create(self: GenericModelService[T], data: dict, context: dict) -> T:
         """
         Cria uma nova instância do modelo.
 
@@ -34,7 +34,7 @@ class ServiceCreateMixin:
         return model_repository.create(**data)
 
 
-class ServiceReadMixin:
+class ServiceReadMixin[T: Model]:
     """
     Mixin para ler instâncias de um modelo em um serviço.
 
@@ -43,7 +43,7 @@ class ServiceReadMixin:
         list: Lista instâncias filtradas do modelo.
     """
 
-    def read(self, id: UUID | int, context: dict) -> Model:
+    def read(self: GenericModelService[T], id: UUID | int, context: dict) -> T:
         """
         Lê uma instância específica pelo ID.
 
@@ -57,7 +57,7 @@ class ServiceReadMixin:
         model_repository = self.get_model_repository()
         return model_repository.read(id)
 
-    def list(self, context: dict, **kwargs) -> QuerySet[Model]:
+    def list(self: GenericModelService[T], context: dict, **kwargs) -> QuerySet[T]:
         """
         Lista instâncias filtradas do modelo.
 
@@ -72,7 +72,7 @@ class ServiceReadMixin:
         return model_repository.filter(**kwargs)
 
 
-class ServiceUpdateMixin:
+class ServiceUpdateMixin[T: Model]:
     """
     Mixin para atualizar instâncias de um modelo em um serviço.
 
@@ -80,7 +80,9 @@ class ServiceUpdateMixin:
         update: Atualiza uma instância específica pelo ID.
     """
 
-    def update(self, id: UUID | int, data: dict, context: dict) -> Model:
+    def update(
+        self: GenericModelService[T], id: UUID | int, data: dict, context: dict
+    ) -> T:
         """
         Atualiza uma instância específica pelo ID.
 
@@ -96,7 +98,7 @@ class ServiceUpdateMixin:
         return model_repository.update(id, **data)
 
 
-class ServiceDeleteMixin:
+class ServiceDeleteMixin[T: Model]:
     """
     Mixin para excluir instâncias de um modelo em um serviço.
 
@@ -104,7 +106,7 @@ class ServiceDeleteMixin:
         delete: Exclui uma instância específica pelo ID.
     """
 
-    def delete(self, id: UUID | int, context: dict) -> None:
+    def delete(self: GenericModelService[T], id: UUID | int, context: dict) -> None:
         """
         Exclui uma instância específica pelo ID.
 
@@ -117,6 +119,10 @@ class ServiceDeleteMixin:
         """
         model_repository = self.get_model_repository()
         return model_repository.delete(id)
+
+
+# NOTE: couldn't find a way to tell that self should behave both like a GenericModelView
+# and a mixin at the same time (needed as they call their own methods here)
 
 
 class ViewCreateModelMixin:

--- a/django_inscode/permissions.py
+++ b/django_inscode/permissions.py
@@ -60,8 +60,8 @@ class AND:
 
     @property
     def message(self):
-        msg1 = getattr(self.op1, 'message', 'Permissão negada.')
-        msg2 = getattr(self.op2, 'message', 'Permissão negada.')
+        msg1 = getattr(self.op1, "message", "Permissão negada.")
+        msg2 = getattr(self.op2, "message", "Permissão negada.")
         if msg1 == msg2:
             return msg1
         return f"{msg1} e {msg2}"
@@ -84,8 +84,8 @@ class OR:
 
     @property
     def message(self):
-        msg1 = getattr(self.op1, 'message', 'Permissão negada.')
-        msg2 = getattr(self.op2, 'message', 'Permissão negada.')
+        msg1 = getattr(self.op1, "message", "Permissão negada.")
+        msg2 = getattr(self.op2, "message", "Permissão negada.")
         if msg1 == msg2:
             return msg1
         return f"{msg1} ou {msg2}"
@@ -111,7 +111,7 @@ class NOT:
 
     @property
     def message(self):
-        msg = getattr(self.op1, 'message', 'Permissão negada.')
+        msg = getattr(self.op1, "message", "Permissão negada.")
         return f"(Não) {msg}"
 
     def has_permission(self, request, view):

--- a/django_inscode/repositories.py
+++ b/django_inscode/repositories.py
@@ -13,6 +13,8 @@ from django.db.models import Manager, Model, Q, QuerySet
 from django.db.models.fields.related import ManyToManyField, ManyToManyRel
 from django_softdelete.models import SoftDeleteModel
 
+from django_inscode.types import Id
+
 from .exceptions import BadRequest, InternalServerError, NotFound
 
 
@@ -55,12 +57,12 @@ class IRepository[T: Model](ABC):
         pass
 
     @abstractmethod
-    def read(self, id: UUID | int) -> T:
+    def read(self, id: Id) -> T:
         """
         Busca uma instância existente no banco de dados via ID.
 
         Args:
-            id (UUID | int): Identificador da instância.
+            id ((UUID, int)): Identificador da instância.
 
         Returns:
             Model: Instância encontrada do modelo.
@@ -71,12 +73,12 @@ class IRepository[T: Model](ABC):
         pass
 
     @abstractmethod
-    def update(self, id: UUID | int, **data) -> T:
+    def update(self, id: Id, **data) -> T:
         """
         Atualiza uma instância existente no banco de dados.
 
         Args:
-            id (UUID | int): Identificador da instância a ser atualizada.
+            id ((UUID, int)): Identificador da instância a ser atualizada.
             **data: Dados para atualização da instância.
 
         Returns:
@@ -90,12 +92,12 @@ class IRepository[T: Model](ABC):
         pass
 
     @abstractmethod
-    def delete(self, id: UUID | int) -> None:
+    def delete(self, id: Id) -> None:
         """
         Exclui uma instância existente no banco de dados via ID.
 
         Args:
-            id (UUID | int): Identificador da instância a ser excluída.
+            id ((UUID, int)): Identificador da instância a ser excluída.
 
         Raises:
             NotFound: Se a instância não for encontrada.
@@ -336,12 +338,12 @@ class Repository[T: Model](IRepository[T]):
             for obj in deleted_qs:
                 obj.hard_delete()
 
-    def read(self, id: UUID | int) -> T:
+    def read(self, id: Id) -> T:
         """
         Busca uma instância existente no banco de dados via ID.
 
         Args:
-            id (UUID | int): Identificador da instância.
+            id ((UUID, int)): Identificador da instância.
 
         Returns:
             Model: Instância encontrada do modelo.
@@ -355,7 +357,7 @@ class Repository[T: Model](IRepository[T]):
         except self.model.DoesNotExist:
             raise NotFound(message=f"{self.model._meta.object_name} não encontrado")
 
-    def update(self, id: UUID | int, **data) -> T:
+    def update(self, id: Id, **data) -> T:
         """
         Atualiza uma instância existente e seus relacionamentos many-to-many (diretos e inversos).
 
@@ -425,12 +427,12 @@ class Repository[T: Model](IRepository[T]):
 
         return instance
 
-    def delete(self, id: UUID | int) -> None:
+    def delete(self, id: Id) -> None:
         """
         Exclui uma instância existente no banco de dados via ID.
 
         Args:
-            id (UUID | int): Identificador da instância a ser excluída.
+            id ((UUID, int)): Identificador da instância a ser excluída.
 
         Raises:
             NotFound: Se a instância não for encontrada.

--- a/django_inscode/repositories.py
+++ b/django_inscode/repositories.py
@@ -1,26 +1,22 @@
 from abc import ABC, abstractmethod
-from django.db import transaction
-from django.db.models import Model, QuerySet, Manager, Q
-from django.utils.translation import gettext as _
-from django.core.exceptions import (
-    ValidationError,
-    ObjectDoesNotExist,
-    FieldDoesNotExist,
-)
-from django.db.models.fields.related import ManyToManyRel, ManyToManyField
-from django.apps import apps
-
-from django_softdelete.models import SoftDeleteModel
-
+from typing import Any, cast
 from uuid import UUID
-from typing import TypeVar, List, Dict, Any, Generic
+
+from django.apps import apps
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    ObjectDoesNotExist,
+    ValidationError,
+)
+from django.db import transaction
+from django.db.models import Manager, Model, Q, QuerySet
+from django.db.models.fields.related import ManyToManyField, ManyToManyRel
+from django_softdelete.models import SoftDeleteModel
 
 from .exceptions import BadRequest, InternalServerError, NotFound
 
-T = TypeVar("T", bound=Model)
 
-
-class IRepository(ABC, Generic[T]):
+class IRepository[T: Model](ABC):
     """
     Interface abstrata que define o contrato para repositórios.
 
@@ -32,7 +28,7 @@ class IRepository(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def __init__(self, model: T) -> None:
+    def __init__(self, model: type[T]) -> None:
         """
         Inicializa o repositório com o modelo Django associado.
 
@@ -132,7 +128,7 @@ class IRepository(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def manager(self) -> Manager[Model]:
+    def manager(self) -> Manager[T]:
         """
         Retorna o manager para consultas mais complexas.
 
@@ -142,7 +138,7 @@ class IRepository(ABC, Generic[T]):
         pass
 
 
-class Repository(IRepository):
+class Repository[T: Model](IRepository[T]):
     """
     Repositório genérico para manipulação de modelos Django.
 
@@ -153,16 +149,16 @@ class Repository(IRepository):
         model (Model): O modelo Django associado ao repositório.
     """
 
-    def __init__(self, model: T):
+    def __init__(self, model: type[T]):
         """
         Inicializa o repositório com o modelo Django associado.
 
         Args:
-            model (Model): O modelo Django que será manipulado pelo repositório.
+            model (type[Model]): O modelo Django que será manipulado pelo repositório.
         """
         self.model = model
 
-    def _format_validation_errors(self, error: ValidationError) -> List[Dict[str, Any]]:
+    def _format_validation_errors(self, error: ValidationError) -> list[dict[str, Any]]:
         """
         Formata os erros de validação do Django no formato esperado.
 
@@ -170,7 +166,7 @@ class Repository(IRepository):
             error (ValidationError): Exceção de validação capturada.
 
         Returns:
-            List[Dict[str, Any]]: Lista de dicionários contendo os campos e mensagens de erro.
+            list[dict[str, Any]]: Lista de dicionários contendo os campos e mensagens de erro.
         """
         errors = []
         if hasattr(error, "error_dict"):
@@ -193,14 +189,14 @@ class Repository(IRepository):
         return errors
 
     def _save(
-        self, instance: T, many_to_many_data: Dict[str, List[Any]] = None
+        self, instance: T, many_to_many_data: dict[str, list[Any]] | None = None
     ) -> None:
         """
         Salva a instância no banco de dados, incluindo campos ManyToMany.
 
         Args:
             instance (Model): Instância do modelo a ser salva.
-            many_to_many_data (Dict[str, List[Any]], optional): Dados para campos ManyToMany.
+            many_to_many_data (dict[str, list[Any]], optional): Dados para campos ManyToMany.
 
         Raises:
             BadRequest: Se houver problemas nos dados fornecidos.
@@ -221,7 +217,7 @@ class Repository(IRepository):
 
                         except FieldDoesNotExist:
                             raise BadRequest(
-                                message=f"Campo inexistente.",
+                                message="Campo inexistente.",
                                 errors={
                                     f"{field_name}": "Este campo não existe no modelo."
                                 },
@@ -229,7 +225,7 @@ class Repository(IRepository):
 
                         if not isinstance(value, (list, QuerySet)):
                             raise BadRequest(
-                                message=f"Valor inválido para o campo ManyToMany.",
+                                message="Valor inválido para o campo ManyToMany.",
                                 errors={
                                     f"{field_name}": "Esperada uma lista de IDs ou instâncias."
                                 },
@@ -251,7 +247,7 @@ class Repository(IRepository):
                                     missing_ids = set(ids) - ids_found
 
                                     raise BadRequest(
-                                        message=f"Alguns objetos relacionados não foram encontrados.",
+                                        message="Alguns objetos relacionados não foram encontrados.",
                                         errors={
                                             f"{field_name}": f"IDs inválidos: {missing_ids}."
                                         },
@@ -259,7 +255,7 @@ class Repository(IRepository):
 
                             except (ValueError, AttributeError):
                                 raise BadRequest(
-                                    message=f"IDs inválidos.",
+                                    message="IDs inválidos.",
                                     errors={
                                         f"{field_name}": "IDs malformados.",
                                     },
@@ -299,7 +295,7 @@ class Repository(IRepository):
                     many_to_many_data[field_name] = value
             except FieldDoesNotExist:
                 raise BadRequest(
-                    message=f"Campo inexistente.",
+                    message="Campo inexistente.",
                     errors={f"{field_name}": "Este campo não existe no modelo."},
                 )
 
@@ -336,7 +332,7 @@ class Repository(IRepository):
                 query |= Q(**filters)
 
         if query:
-            deleted_qs = self.model.deleted_objects.filter(query)
+            deleted_qs = cast(SoftDeleteModel, self.model).deleted_objects.filter(query)
             for obj in deleted_qs:
                 obj.hard_delete()
 
@@ -470,7 +466,7 @@ class Repository(IRepository):
         return self.model.objects.filter(**kwargs)
 
     @property
-    def manager(self) -> Manager[Model]:
+    def manager(self) -> Manager[T]:
         """
         Retorna o manager para consultas mais complexas. Equivalente a acessar Model.objects
 
@@ -487,7 +483,7 @@ def get_repository(model: str) -> Repository:
     if not isinstance(model, str):
         raise ValueError("model must be a string")
 
-    if not model in __REPOSITORIES.keys():
+    if model not in __REPOSITORIES.keys():
         raise ValueError(f"model not registered in django apps: {model}")
 
     return __REPOSITORIES[model]

--- a/django_inscode/serializers.py
+++ b/django_inscode/serializers.py
@@ -1,32 +1,27 @@
+import datetime
 from dataclasses import fields, is_dataclass
+from decimal import Decimal
 from typing import (
     Any,
-    Dict,
-    List,
-    Optional,
+    Protocol,
     Union,
     get_args,
     get_origin,
-    Protocol,
-    Type,
 )
-from decimal import Decimal
 from uuid import UUID
 
 from django.db import models
-from django.core.files.base import File
-
+from django.db.models import Model
+from django.db.models.fields.files import FieldFile
 from marshmallow import Schema
 
 from .transports import Transport
 
-import datetime
-
-SerializedData = Dict[str, Any]
+SerializedData = dict[str, Any]
 
 
 class SerializerInterface(Protocol):
-    def serialize(self, obj: Any) -> SerializedData: ...
+    def serialize(self, instance: Any) -> SerializedData: ...
 
 
 class MarshmallowSerializerAdapter(SerializerInterface):
@@ -34,11 +29,11 @@ class MarshmallowSerializerAdapter(SerializerInterface):
     Adaptador do serializador do marshmallow para a interface de SerializerInterface.
     """
 
-    def __init__(self, schema_class: Type[Schema]):
+    def __init__(self, schema_class: type[Schema]):
         self.schema_class = schema_class
 
-    def serialize(self, obj: Schema):
-        return self.schema_class().dump(obj)
+    def serialize(self, instance: Any):
+        return self.schema_class().dump(instance)
 
 
 class Serializer(SerializerInterface):
@@ -49,17 +44,17 @@ class Serializer(SerializerInterface):
     serializados a partir de uma instância do modelo associado.
 
     Attributes:
-        model (Model): O modelo Django associado ao serializador.
-        transport (Type[Transport]): Classe de transporte que define os campos e tipos para serialização.
+        model (type[Model]): O modelo Django associado ao serializador.
+        transport (type[Transport]): Classe de transporte que define os campos e tipos para serialização.
     """
 
-    def __init__(self, model: models.Model, transport: Type[Transport]):
+    def __init__(self, model: type[models.Model], transport: type[Transport]):
         """
         Inicializa o serializador com o modelo e o transporte especificados.
 
         Args:
-            model (Model): O modelo Django que será serializado.
-            transport (Type[Transport]): Classe de transporte que define os campos e tipos para serialização.
+            model (type[Model]): O modelo Django que será serializado.
+            transport (type[Transport]): Classe de transporte que define os campos e tipos para serialização.
 
         Raises:
             ValueError: Se `transport` não for uma subclasse de `Transport`.
@@ -70,7 +65,7 @@ class Serializer(SerializerInterface):
         self.model = model
         self.transport = transport
 
-    def serialize(self, instance) -> Dict[str, Any]:
+    def serialize(self, instance: Model) -> SerializedData:
         """
         Serializa uma instância do modelo em um dicionário com base no transporte.
 
@@ -78,7 +73,7 @@ class Serializer(SerializerInterface):
             instance (Model): Instância do modelo a ser serializada.
 
         Returns:
-            Dict[str, Any]: Dicionário contendo os dados serializados da instância.
+            dict[str, Any]: Dicionário contendo os dados serializados da instância.
 
         Raises:
             ValueError: Se o transporte não for uma subclasse de `Transport` ou se a instância não for do tipo esperado.
@@ -121,7 +116,7 @@ class Serializer(SerializerInterface):
             UUID: self._serialize_uuid,
             datetime.date: self._serialize_date,
             datetime.datetime: self._serialize_date,
-            File: self._serialize_file,
+            FieldFile: self._serialize_file,
         }
 
         for base_type, serializer_func in type_serializers.items():
@@ -131,10 +126,10 @@ class Serializer(SerializerInterface):
         origin = get_origin(field_type)
         args = get_args(field_type)
 
-        if origin in [list, List]:
+        if origin is list:
             return self._serialize_list(value, args[0])
 
-        if origin in [dict, Dict]:
+        if origin is dict:
             return self._serialize_dict(value, args)
 
         if origin is Union and type(None) in args:
@@ -162,15 +157,15 @@ class Serializer(SerializerInterface):
         """Serializa datas e datetimes como strings ISO 8601."""
         return value.isoformat()
 
-    def _serialize_file(self, value: File) -> Optional[str]:
+    def _serialize_file(self, value: FieldFile) -> str | None:
         """Serializa arquivos como URLs."""
         return value.url if value else None
 
-    def _serialize_list(self, value: List[Any], item_type: Any) -> List[Any]:
+    def _serialize_list(self, value: list[Any], item_type: Any) -> list[Any]:
         """Serializa listas recursivamente."""
         return [self._serialize(item, item_type) for item in value]
 
-    def _serialize_dict(self, value: Dict[Any, Any], types: tuple) -> Dict[Any, Any]:
+    def _serialize_dict(self, value: dict[Any, Any], types: tuple) -> dict[Any, Any]:
         """Serializa dicionários recursivamente."""
         key_type, value_type = types
         return {
@@ -180,7 +175,7 @@ class Serializer(SerializerInterface):
 
     def _serialize_transport(
         self, value: models.Model, transport_type: Any
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Serializa objetos relacionados usando transportes aninhados."""
         model_class = type(value)
         return Serializer(model=model_class, transport=transport_type).serialize(value)

--- a/django_inscode/services.py
+++ b/django_inscode/services.py
@@ -1,12 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import Literal, Protocol, runtime_checkable
-from uuid import UUID
 
 from django.db.models import Model, QuerySet
 
 from . import mixins
 from .repositories import IRepository
-from .types import Context, Data
+from .types import Context, Data, Id
 
 Action = Literal["create", "read", "update", "delete", "list", "list_all"]
 
@@ -18,18 +17,18 @@ class ServiceCreateProtocol(Protocol):
 
 @runtime_checkable
 class ServiceReadProtocol(Protocol):
-    def read(self, id: UUID | int, context: Context) -> Model: ...
+    def read(self, id: Id, context: Context) -> Model: ...
     def list(self, context: Context, **kwargs) -> QuerySet[Model]: ...
 
 
 @runtime_checkable
 class ServiceUpdateProtocol(Protocol):
-    def update(self, id: UUID | int, data: dict, context: Context) -> Model: ...
+    def update(self, id: Id, data: dict, context: Context) -> Model: ...
 
 
 @runtime_checkable
 class ServiceDeleteProtocol(Protocol):
-    def delete(self, id: UUID | int, context: Context) -> None: ...
+    def delete(self, id: Id, context: Context) -> None: ...
 
 
 class OrchestratorService(ABC):

--- a/django_inscode/services.py
+++ b/django_inscode/services.py
@@ -1,12 +1,13 @@
-from . import mixins
-from .repositories import Repository
-
-from typing import Dict, Optional, Any, Literal
 from abc import ABC, abstractmethod
+from typing import Any, Literal, Protocol, runtime_checkable
+from uuid import UUID
 
-from django.db.models import Model
+from django.db.models import Model, QuerySet
 
-Data = Dict[str, Any]
+from . import mixins
+from .repositories import IRepository
+
+Data = dict[str, Any]
 Action = Literal["create", "read", "update", "delete", "list", "list_all"]
 
 
@@ -36,7 +37,7 @@ class OrchestratorService(ABC):
         pass
 
 
-class GenericModelService:
+class GenericModelService[T: Model]:
     """
     Classe genérica para servir como base para serviços de modelos.
 
@@ -48,7 +49,7 @@ class GenericModelService:
         repository (Repository): O repositório associado ao modelo.
     """
 
-    def __init__(self, repository: Repository):
+    def __init__(self, repository: IRepository[T]):
         """
         Inicializa o serviço com o repositório associado.
 
@@ -57,7 +58,7 @@ class GenericModelService:
         """
         self.repository = repository
 
-    def get_model_repository(self):
+    def get_model_repository(self) -> IRepository[T]:
         """
         Retorna o repositório associado ao modelo.
 
@@ -66,7 +67,9 @@ class GenericModelService:
         """
         return self.repository
 
-    def validate(self, data: Data, instance: Optional[Model] = None) -> Optional[Data]:
+    def validate(
+        self, data: Data, instance: Model | None = None, **kwargs
+    ) -> Data | None:
         """
         Valida os dados fornecidos durante uma ação de criação ou atualização.
 
@@ -138,8 +141,8 @@ class GenericModelService:
             raise ValueError(f"Ação desconhecida ou inválida: {action}")
 
 
-class ModelService(
-    GenericModelService,
+class ModelService[T: Model](
+    GenericModelService[T],
     mixins.ServiceCreateMixin,
     mixins.ServiceReadMixin,
     mixins.ServiceUpdateMixin,

--- a/django_inscode/services.py
+++ b/django_inscode/services.py
@@ -1,35 +1,35 @@
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 from uuid import UUID
 
 from django.db.models import Model, QuerySet
 
 from . import mixins
 from .repositories import IRepository
+from .types import Context, Data
 
-Data = dict[str, Any]
 Action = Literal["create", "read", "update", "delete", "list", "list_all"]
 
 
 @runtime_checkable
 class ServiceCreateProtocol(Protocol):
-    def create(self, data: dict, context: dict) -> Model: ...
+    def create(self, data: dict, context: Context) -> Model: ...
 
 
 @runtime_checkable
 class ServiceReadProtocol(Protocol):
-    def read(self, id: UUID | int, context: dict) -> Model: ...
-    def list(self, context: dict, **kwargs) -> QuerySet[Model]: ...
+    def read(self, id: UUID | int, context: Context) -> Model: ...
+    def list(self, context: Context, **kwargs) -> QuerySet[Model]: ...
 
 
 @runtime_checkable
 class ServiceUpdateProtocol(Protocol):
-    def update(self, id: UUID | int, data: dict, context: dict) -> Model: ...
+    def update(self, id: UUID | int, data: dict, context: Context) -> Model: ...
 
 
 @runtime_checkable
 class ServiceDeleteProtocol(Protocol):
-    def delete(self, id: UUID | int, context: dict) -> None: ...
+    def delete(self, id: UUID | int, context: Context) -> None: ...
 
 
 class OrchestratorService(ABC):
@@ -89,7 +89,7 @@ class GenericModelService[T: Model]:
         return self.repository
 
     def validate(
-        self, data: Data, instance: Model | None = None, **kwargs
+        self, data: Data, context: Context, instance: T | None = None
     ) -> Data | None:
         """
         Valida os dados fornecidos durante uma ação de criação ou atualização.
@@ -134,10 +134,10 @@ class GenericModelService[T: Model]:
         """
         data = kwargs.get("data", {})
         filter_kwargs = kwargs.get("filter_kwargs", {})
-        context = kwargs.get("context", {})
+        context: Context = kwargs.get("context", {})
 
         if action == "create" and isinstance(self, ServiceCreateProtocol):
-            validated_data: Data | None = self.validate(data)
+            validated_data: Data | None = self.validate(data, context)
             return self.create(
                 validated_data if validated_data is not None else data, context
             )
@@ -148,7 +148,9 @@ class GenericModelService[T: Model]:
         elif action == "update" and isinstance(self, ServiceUpdateProtocol):
             pk = args[0]
             instance = self.repository.read(pk)
-            validated_data: Data | None = self.validate(data, instance=instance)
+            validated_data: Data | None = self.validate(
+                data, context, instance=instance
+            )
             return self.update(
                 *args,
                 data=validated_data if validated_data is not None else data,

--- a/django_inscode/services.py
+++ b/django_inscode/services.py
@@ -11,6 +11,27 @@ Data = dict[str, Any]
 Action = Literal["create", "read", "update", "delete", "list", "list_all"]
 
 
+@runtime_checkable
+class ServiceCreateProtocol(Protocol):
+    def create(self, data: dict, context: dict) -> Model: ...
+
+
+@runtime_checkable
+class ServiceReadProtocol(Protocol):
+    def read(self, id: UUID | int, context: dict) -> Model: ...
+    def list(self, context: dict, **kwargs) -> QuerySet[Model]: ...
+
+
+@runtime_checkable
+class ServiceUpdateProtocol(Protocol):
+    def update(self, id: UUID | int, data: dict, context: dict) -> Model: ...
+
+
+@runtime_checkable
+class ServiceDeleteProtocol(Protocol):
+    def delete(self, id: UUID | int, context: dict) -> None: ...
+
+
 class OrchestratorService(ABC):
     """
     Classe base para serviços orquestradores.
@@ -115,27 +136,25 @@ class GenericModelService[T: Model]:
         filter_kwargs = kwargs.get("filter_kwargs", {})
         context = kwargs.get("context", {})
 
-        if action == "create" and isinstance(self, mixins.ServiceCreateMixin):
-            validated_data: Optional[Data] = self.validate(data)
+        if action == "create" and isinstance(self, ServiceCreateProtocol):
+            validated_data: Data | None = self.validate(data)
             return self.create(
                 validated_data if validated_data is not None else data, context
             )
-        elif action == "read" and isinstance(self, mixins.ServiceReadMixin):
+        elif action == "read" and isinstance(self, ServiceReadProtocol):
             return self.read(*args, context=context)
-        elif action == "list_all" and isinstance(self, mixins.ServiceReadMixin):
-            return self.list_all(context=context)
-        elif action == "list" and isinstance(self, mixins.ServiceReadMixin):
+        elif action == "list" and isinstance(self, ServiceReadProtocol):
             return self.list(context=context, **filter_kwargs)
-        elif action == "update" and isinstance(self, mixins.ServiceUpdateMixin):
+        elif action == "update" and isinstance(self, ServiceUpdateProtocol):
             pk = args[0]
             instance = self.repository.read(pk)
-            validated_data: Optional[Data] = self.validate(data, instance=instance)
+            validated_data: Data | None = self.validate(data, instance=instance)
             return self.update(
                 *args,
                 data=validated_data if validated_data is not None else data,
                 context=context,
             )
-        elif action == "delete" and isinstance(self, mixins.ServiceDeleteMixin):
+        elif action == "delete" and isinstance(self, ServiceDeleteProtocol):
             return self.delete(*args, context=context)
         else:
             raise ValueError(f"Ação desconhecida ou inválida: {action}")
@@ -143,10 +162,10 @@ class GenericModelService[T: Model]:
 
 class ModelService[T: Model](
     GenericModelService[T],
-    mixins.ServiceCreateMixin,
-    mixins.ServiceReadMixin,
-    mixins.ServiceUpdateMixin,
-    mixins.ServiceDeleteMixin,
+    mixins.ServiceCreateMixin[T],
+    mixins.ServiceReadMixin[T],
+    mixins.ServiceUpdateMixin[T],
+    mixins.ServiceDeleteMixin[T],
 ):
     """
     Serviço que fornece ações CRUD (criar, ler, atualizar e excluir) para um modelo.

--- a/django_inscode/types.py
+++ b/django_inscode/types.py
@@ -1,4 +1,5 @@
-from typing import Any, TypedDict
+from typing import Any, TypedDict, TypeVar
+from uuid import UUID
 
 type Data = dict[str, Any]
 
@@ -8,3 +9,6 @@ class Context(TypedDict):
     session: Any
     url_params: dict
     query_params: dict
+
+
+Id = TypeVar("Id", UUID, int)

--- a/django_inscode/types.py
+++ b/django_inscode/types.py
@@ -1,0 +1,10 @@
+from typing import Any, TypedDict
+
+type Data = dict[str, Any]
+
+
+class Context(TypedDict):
+    user: Any
+    session: Any
+    url_params: dict
+    query_params: dict

--- a/django_inscode/utils/date.py
+++ b/django_inscode/utils/date.py
@@ -1,9 +1,7 @@
-from django.conf import settings as django_settings
-
 from datetime import datetime
 
-from django_inscode import settings
 import pytz
+from django.conf import settings as django_settings
 
 
 def get_actual_datetime() -> datetime:

--- a/django_inscode/utils/marshmallow.py
+++ b/django_inscode/utils/marshmallow.py
@@ -1,0 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from marshmallow import Schema
+
+
+def get_updatable_fields(schema: "Schema") -> set[str]:
+    return {k for k, v in schema.fields.items() if v.metadata.get("updatable", True)}

--- a/django_inscode/views.py
+++ b/django_inscode/views.py
@@ -1,19 +1,18 @@
-from django.views import View
-from django.core.exceptions import ImproperlyConfigured
+from typing import Any, ClassVar, cast
+
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Model
 from django.http import HttpRequest, JsonResponse
 from django.utils.module_loading import import_string
-from django.conf import settings
+from django.views import View
 
-from typing import Set, Dict, Any, List, Union, ClassVar, Optional, Type
-
-from . import mixins
-from . import exceptions
-
-from .permissions import BasePermission
-from .services import GenericModelService, OrchestratorService
-from .serializers import SerializerInterface, SerializerFactory
+from . import exceptions, mixins
 from .authentication import BaseAuthentication
+from .permissions import BasePermission
+from .serializers import SerializerFactory, SerializerInterface
+from .services import GenericModelService, OrchestratorService
 
 try:
     from marshmallow import Schema, ValidationError
@@ -23,10 +22,10 @@ except ImportError:
 
 import json
 
-Serializer = Union[Schema, SerializerInterface]
-Service = Union[GenericModelService, OrchestratorService]
-Context = Dict[str, Any]
-Data = Dict[str, Any]
+Serializer = Schema | SerializerInterface
+Service = GenericModelService | OrchestratorService
+Context = dict[str, Any]
+Data = dict[str, Any]
 
 
 class GenericView(View):
@@ -38,17 +37,19 @@ class GenericView(View):
 
     Attributes:
         service (Service): Serviço associado à view.
-        permissions_classes (List[Type[BasePermission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view (validação simples).
-        input_schema (Optional[Type[Schema]]): Schema marshmallow para validação de entrada.
+        permissions_classes (list[type[BasePermission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view (validação simples).
+        input_schema (type[Schema] | None): Schema marshmallow para validação de entrada.
             Se definido, tem prioridade sobre o campo 'fields'.
     """
 
-    service: ClassVar[Service] = None
-    permissions_classes: ClassVar[List[BasePermission]] = None
-    fields: ClassVar[List[str]] = []
-    authentication_classes: ClassVar[List[BaseAuthentication]] = []
-    input_schema: ClassVar[Optional[Type[Schema]]] = None
+    service: ClassVar[Service] = cast(Service, None)
+    permissions_classes: ClassVar[list[type[BasePermission]]] = cast(
+        list[type[BasePermission]], None
+    )
+    fields: ClassVar[set[str]] = set()
+    authentication_classes: ClassVar[list[type[BaseAuthentication]]] = []
+    input_schema: ClassVar[type[Schema] | None] = None
 
     def __init__(self, **kwargs) -> None:
         """
@@ -63,7 +64,8 @@ class GenericView(View):
         if not self.authentication_classes:
             self.authentication_classes = self.get_default_authentication_classes()
 
-    def get_default_authentication_classes(self) -> List[BaseAuthentication]:
+    @staticmethod
+    def get_default_authentication_classes() -> list[type[BaseAuthentication]]:
         """
         Retorna a lista de classes de autenticação padrão.
 
@@ -89,7 +91,7 @@ class GenericView(View):
             except exceptions.Unauthorized as e:
                 raise exceptions.Unauthorized(str(e))
 
-    def _parse_request_data(self, request: HttpRequest) -> Dict[str, Any]:
+    def _parse_request_data(self, request: HttpRequest) -> dict[str, Any]:
         """
         Analisa os dados da requisição com base no tipo de conteúdo.
 
@@ -97,7 +99,7 @@ class GenericView(View):
             request (HttpRequest): Objeto da requisição HTTP.
 
         Returns:
-            Dict[str, Any]: Dados analisados da requisição.
+            dict[str, Any]: Dados analisados da requisição.
 
         Raises:
             ValueError: Se o formato do conteúdo não for suportado ou se o JSON for inválido.
@@ -158,12 +160,12 @@ class GenericView(View):
             "query_params": request.GET.dict(),
         }
 
-    def get_permissions(self) -> List[BasePermission]:
+    def get_permissions(self) -> list[BasePermission]:
         """
         Instancia e retorna as classes de permissão configuradas.
 
         Returns:
-            List[BasePermission]: Lista de instâncias das classes de permissão.
+            list[BasePermission]: Lista de instâncias das classes de permissão.
         """
         if not self.permissions_classes:
             return []
@@ -191,16 +193,16 @@ class GenericView(View):
             if obj and not permission.has_object_permission(request, self, obj):
                 raise exceptions.Forbidden(message=permission.message)
 
-    def get_fields(self) -> Set[str]:
+    def get_fields(self) -> set[str]:
         """
         Retorna os campos obrigatórios para requisições de criação.
 
         Returns:
             Set[str]: Conjunto de nomes dos campos permitidos.
         """
-        return self.fields or []
+        return self.fields or set()
 
-    def verify_fields(self, data: Data, request: HttpRequest = None) -> None:
+    def verify_fields(self, data: Data, request: HttpRequest | None = None) -> None:
         """
         Verifica se todos os campos obrigatórios estão presentes nos dados.
 
@@ -218,7 +220,9 @@ class GenericView(View):
             if not (request and request.method == "PATCH"):
                 self._validate_simple_fields(data)
 
-    def _validate_with_schema(self, data: Data, request: HttpRequest = None) -> None:
+    def _validate_with_schema(
+        self, data: Data, request: HttpRequest | None = None
+    ) -> None:
         """
         Valida os dados usando o schema marshmallow definido.
 
@@ -238,8 +242,9 @@ class GenericView(View):
             )
 
         try:
-            is_partial = request and request.method == "PATCH"
+            is_partial = request is not None and request.method == "PATCH"
 
+            assert self.input_schema is not None
             schema = self.input_schema()
             validated_data = schema.load(data, partial=is_partial)
             data.clear()
@@ -319,11 +324,14 @@ class GenericOrchestratorView(GenericView):
 
     Attributes:
         service (OrchestratorService): Serviço orquestrador associado à view.
-        permissions_classes (List[Type[BasePermission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view.
+        permissions_classes (list[type[BasePermission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view.
     """
 
-    service: ClassVar[OrchestratorService] = None
+    service: ClassVar[OrchestratorService] = cast(OrchestratorService, None)
+
+    def get_service(self) -> OrchestratorService:
+        return cast(OrchestratorService, super().get_service())
 
     def execute(self, request: HttpRequest, *args, **kwargs) -> JsonResponse:
         """
@@ -364,12 +372,12 @@ class GenericModelView(GenericView):
     Attributes:
         serializer (SerializerInterface): Classe de serializador associada à view.
         service (GenericModelService): Serviço associado à view.
-        permissions_classes (List[Type[BasePermission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view.
+        permissions_classes (list[type[BasePermission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view.
     """
 
-    serializer: ClassVar[Serializer] = None
-    service: ClassVar[GenericModelService] = None
+    serializer: ClassVar[Serializer] = cast(Serializer, None)
+    service: ClassVar[GenericModelService] = cast(GenericModelService, None)
     lookup_field: ClassVar[str] = "pk"
 
     def _validate_required_attributes(self):
@@ -441,7 +449,7 @@ class GenericModelView(GenericView):
             obj (Model): Instância do modelo a ser serializada.
 
         Returns:
-            Dict[str, Any]: Dicionário contendo os dados serializados da instância.
+            dict[str, Any]: Dicionário contendo os dados serializados da instância.
 
         Raises:
             ValueError: Se ocorrer um erro durante a serialização.
@@ -457,8 +465,8 @@ class CreateModelView(GenericModelView, mixins.ViewCreateModelMixin):
     Attributes:
         serializer (t_serializer): Classe de serializador associada à view.
         service (t_service): Serviço associado à view.
-        permissions_classes (List[Type[t_permission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view.
+        permissions_classes (list[type[t_permission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view.
     """
 
 
@@ -471,7 +479,7 @@ class RetrieveModelView(GenericModelView, mixins.ViewRetrieveModelMixin):
         lookup_field (str): Nome do campo usado para identificar instâncias específicas. Default é "pk".
         paginate_by (int): Número de itens por página para paginação. Default é definido em `settings.DEFAULT_PAGINATED_BY`.
         service (t_service): Serviço associado à view.
-        permissions_classes (List[Type[t_permission]]): Lista de classes de permissão.
+        permissions_classes (list[type[t_permission]]): Lista de classes de permissão.
     """
 
 
@@ -483,8 +491,8 @@ class UpdateModelView(GenericModelView, mixins.ViewUpdateModelMixin):
         serializer (t_serializer): Classe de serializador associada à view.
         lookup_field (str): Nome do campo usado para identificar instâncias específicas. Default é "pk".
         service (t_service): Serviço associado à view.
-        permissions_classes (List[Type[t_permission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view.
+        permissions_classes (list[type[t_permission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view.
     """
 
 
@@ -496,7 +504,7 @@ class DeleteModelView(GenericModelView, mixins.ViewDeleteModelMixin):
         serializer (t_serializer): Classe de serializador associada à view.
         lookup_field (str): Nome do campo usado para identificar instâncias específicas. Default é "pk".
         service (t_service): Serviço associado à view.
-        permissions_classes (List[Type[t_permission]]): Lista de classes de permissão.
+        permissions_classes (list[type[t_permission]]): Lista de classes de permissão.
     """
 
 
@@ -521,8 +529,8 @@ class ModelView(
         lookup_field (str): Nome do campo usado para identificar instâncias específicas. Default é "pk".
         paginate_by (int): Número de itens por página para paginação. Default é definido em `settings.DEFAULT_PAGINATED_BY`.
         service (GenericModelService): Serviço associado à view.
-        permissions_classes (List[Type[BasePermission]]): Lista de classes de permissão.
-        fields (List[str]): Lista de campos permitidos na view.
+        permissions_classes (list[type[BasePermission]]): Lista de classes de permissão.
+        fields (list[str]): Lista de campos permitidos na view.
     """
 
     pass

--- a/django_inscode/views.py
+++ b/django_inscode/views.py
@@ -361,7 +361,7 @@ class GenericOrchestratorView(GenericView):
         return JsonResponse(result, status=200)
 
 
-class GenericModelView(GenericView):
+class GenericModelView[T: Model](GenericView):
     """
     Classe base genérica que combina mixins para criar views RESTful.
 
@@ -409,7 +409,7 @@ class GenericModelView(GenericView):
         """
         return self.kwargs.get(self.lookup_field)
 
-    def get_object(self):
+    def get_object(self) -> T:
         """
         Recupera uma instância específica do modelo com base no campo de lookup.
 
@@ -508,8 +508,8 @@ class DeleteModelView(GenericModelView, mixins.ViewDeleteModelMixin):
     """
 
 
-class ModelView(
-    GenericModelView,
+class ModelView[T: Model](
+    GenericModelView[T],
     mixins.ViewCreateModelMixin,
     mixins.ViewRetrieveModelMixin,
     mixins.ViewUpdateModelMixin,

--- a/django_inscode/views.py
+++ b/django_inscode/views.py
@@ -8,11 +8,14 @@ from django.http import HttpRequest, JsonResponse
 from django.utils.module_loading import import_string
 from django.views import View
 
+from django_inscode.utils import marshmallow as schema_utils
+
 from . import exceptions, mixins
 from .authentication import BaseAuthentication
 from .permissions import BasePermission
 from .serializers import SerializerFactory, SerializerInterface
 from .services import GenericModelService, OrchestratorService
+from .types import Context, Data
 
 try:
     from marshmallow import Schema, ValidationError
@@ -24,8 +27,6 @@ import json
 
 Serializer = Schema | SerializerInterface
 Service = GenericModelService | OrchestratorService
-Context = dict[str, Any]
-Data = dict[str, Any]
 
 
 class GenericView(View):
@@ -242,11 +243,23 @@ class GenericView(View):
             )
 
         try:
-            is_partial = request is not None and request.method == "PATCH"
+            is_patch = request is not None and request.method == "PATCH"
 
             assert self.input_schema is not None
             schema = self.input_schema()
-            validated_data = schema.load(data, partial=is_partial)
+            validated_data = (
+                schema.load(
+                    {
+                        k: v
+                        for k, v in data.items()
+                        if k in schema_utils.get_updatable_fields(schema)
+                    },
+                    partial=True,
+                )
+                if is_patch
+                else schema.load(data)
+            )
+
             data.clear()
             data.update(validated_data)
         except ValidationError as e:

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ Versão do Python não suportada
 Esta versão do Django Inscode requer o python Python {}.{}, mas você está tentando
 instalar na versão {}.{}.
 
-""".format(
-            *(REQUIRED_PYTHON + CURRENT_PYTHON)
-        )
+""".format(*(REQUIRED_PYTHON + CURRENT_PYTHON))
     )
     sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup, find_packages
 import sys
+
+from setuptools import find_packages, setup
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 12)
@@ -26,7 +27,7 @@ def read(f):
 
 setup(
     name="django-inscode",
-    version="1.7.8",
+    version="2.0.0",
     description="Django framework da Inscode.",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Depends on #51. Adds a feature: updatable fields, allowing you to disallow certain fields from being parsed by the input_schema in a PATCH request through the input_schema's field metadata (`{"updatable": False}`, as by default every field is allowed); and a breaking change: GenericModelService.validate also takes the context now, so that it is possible to validate against its contents without having to override methods like perform_action.

It also cleanses the comments made previously and adds a types.py file with the Context and Data types that were being repeated (also defining the items types for Context).